### PR TITLE
hotfix: fix release notes regex extraction in deploy workflow

### DIFF
--- a/.github/workflows/deploy-on-main-merge.yml
+++ b/.github/workflows/deploy-on-main-merge.yml
@@ -224,7 +224,7 @@ jobs:
           version = os.environ["VERSION"]
           changelog = pathlib.Path("VersionHistory.md").read_text(encoding="utf-8")
           pattern = re.compile(
-              rf"^#{1,2}\s+v{re.escape(version)}\s+\([^)]+\)\n(.*?)(?=^#{1,2}\s+v|\Z)",
+              rf"^#{{1,2}}\s+v{re.escape(version)}\s+\([^)]+\)\n(.*?)(?=^#{{1,2}}\s+v|\Z)",
               re.MULTILINE | re.DOTALL,
           )
           match = pattern.search(changelog)

--- a/.github/workflows/version-integrity-main-pr.yml
+++ b/.github/workflows/version-integrity-main-pr.yml
@@ -37,15 +37,22 @@ jobs:
           if base_ref != "main":
               raise SystemExit(f"This workflow only supports PRs to main, got base={base_ref!r}")
 
-          branch_match = re.fullmatch(r"(release|hotfix)/(\d+\.\d+\.\d+)", head_ref)
-          if not branch_match:
+          if head_ref.startswith("release/"):
+              release_match = re.fullmatch(r"release/(\d+\.\d+\.\d+)", head_ref)
+              if not release_match:
+                  raise SystemExit(
+                      "Release PRs to main must use a SemVer branch suffix "
+                      "(e.g. release/1.2.3)."
+                  )
+              branch_type = "release"
+              branch_version = release_match.group(1)
+          elif head_ref.startswith("hotfix/"):
+              branch_type = "hotfix"
+              branch_version = None
+          else:
               raise SystemExit(
-                  "PRs to main must come from release/* or hotfix/* with SemVer suffix "
-                  "(e.g. release/1.2.3 or hotfix/1.2.3)."
+                  "PRs to main must come from release/* or hotfix/* branches."
               )
-
-          branch_type = branch_match.group(1)
-          branch_version = branch_match.group(2)
 
           pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
           project_version = pyproject["project"]["version"]
@@ -77,10 +84,11 @@ jobs:
               ) from exc
 
           checks = {
-              "branch": branch_version,
               "pyproject.toml": project_version,
               "VersionHistory.md top entry": history_version,
           }
+          if branch_version:
+              checks["release branch suffix"] = branch_version
           if init_version:
               checks["src/mv_laplace/__init__.py"] = init_version
           else:
@@ -94,6 +102,7 @@ jobs:
 
           print("Version integrity check passed.")
           print(f"- Branch type: {branch_type}")
+          print(f"- Branch ref: {head_ref}")
           print(f"- Version: {unique_versions[0]}")
           print(f"- VersionHistory date: {history_date}")
           PY


### PR DESCRIPTION
## Summary
- fix release-notes extraction regex in `.github/workflows/deploy-on-main-merge.yml`
- relax version-integrity workflow branch-name requirement so `hotfix/*` PRs to `main` do not require a SemVer suffix

## Root Causes
1. Release notes regex used `rf"...#{1,2}..."`, where `{1,2}` was interpreted by Python as an f-string expression instead of a regex quantifier.
2. Version integrity workflow required `hotfix/<semver>` naming, which blocked valid hotfix PRs using descriptive branch names.

## Fixes
1. Escaped regex quantifier braces in f-string pattern: `#{{1,2}}`
2. Updated branch validation logic in `version-integrity-main-pr.yml`:
   - `release/*` still requires SemVer suffix (e.g. `release/1.2.3`)
   - `hotfix/*` now accepts non-SemVer suffixes
   - version consistency is still enforced across `pyproject.toml`, `__init__.py` (if present), and `VersionHistory.md`

## Validation
- verified locally that the corrected release-notes pattern matches `VersionHistory.md` and extracts notes.
- validated workflow logic change statically in the updated YAML.

## Impact
- unblocks release-note generation during `release-metadata`.
- unblocks hotfix PRs to `main` when branch names are descriptive instead of SemVer-suffixed.
