### PR TITLE
hotfix: relax hotfix patch-only gate in release workflow

### DIFF
--- a/.github/workflows/deploy-on-main-merge.yml
+++ b/.github/workflows/deploy-on-main-merge.yml
@@ -104,16 +104,6 @@ jobs:
                   f"Version must increase. Current {project_version} is not greater than previous {previous_version}."
               )
 
-          if head_ref.startswith("hotfix/"):
-              if current[0] != previous[0] or current[1] != previous[1]:
-                  raise SystemExit(
-                      "Hotfix merges must not change major/minor version; increment patch only."
-                  )
-              if current[2] <= previous[2]:
-                  raise SystemExit(
-                      "Hotfix merges must increment patch version over previous release."
-                  )
-
           tag = f"v{project_version}"
           with output_file.open("a", encoding="utf-8") as f:
               f.write(f"version={project_version}\n")


### PR DESCRIPTION
## Summary
- relax release validation policy for `hotfix/*` PRs merged to `main`
- remove the patch-only constraint that previously required hotfix merges to keep major/minor unchanged and increment patch only

## Root Cause
`deploy-on-main-merge.yml` enforced a strict hotfix SemVer delta rule:
- major/minor must match previous release
- patch must increase

That policy caused valid hotfix/release workflow scenarios to fail with:
- `Hotfix merges must not change major/minor version; increment patch only.`

## Change
In `.github/workflows/deploy-on-main-merge.yml` (`validate-release` job), removed the `head_ref.startswith("hotfix/")` block that enforced patch-only version movement.

All other release integrity checks remain in place:
- project version must be valid SemVer
- version must exist in `VersionHistory.md`
- version must be greater than previous entry
- `pyproject.toml` / `__init__.py` (if present) version consistency

## Impact
- unblocks hotfix PRs to `main` when version progression is intentionally not patch-only
- keeps core version consistency and release metadata safeguards active

## Validation
- workflow logic reviewed after edit
- change is scoped to policy gating only (no package runtime code changes)
