### PR TITLE
hotfix: v0.2.1 restore strict semver branch/release policy

### DIFF
--- a/.github/workflows/deploy-on-main-merge.yml
+++ b/.github/workflows/deploy-on-main-merge.yml
@@ -104,6 +104,16 @@ jobs:
                   f"Version must increase. Current {project_version} is not greater than previous {previous_version}."
               )
 
+          if head_ref.startswith("hotfix/"):
+              if current[0] != previous[0] or current[1] != previous[1]:
+                  raise SystemExit(
+                      "Hotfix merges must not change major/minor version; increment patch only."
+                  )
+              if current[2] <= previous[2]:
+                  raise SystemExit(
+                      "Hotfix merges must increment patch version over previous release."
+                  )
+
           tag = f"v{project_version}"
           with output_file.open("a", encoding="utf-8") as f:
               f.write(f"version={project_version}\n")

--- a/.github/workflows/gitflow-pr-rules.yml
+++ b/.github/workflows/gitflow-pr-rules.yml
@@ -26,7 +26,7 @@ jobs:
               allowed=true
             fi
           elif [[ "$BASE_REF" == "main" ]]; then
-            if [[ "$HEAD_REF" == release/* || "$HEAD_REF" == hotfix/* ]]; then
+            if [[ "$HEAD_REF" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ || "$HEAD_REF" =~ ^hotfix/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               allowed=true
             fi
           fi
@@ -35,8 +35,8 @@ jobs:
             echo "Invalid GitFlow PR path: '$HEAD_REF' -> '$BASE_REF'"
             echo "Allowed paths:"
             echo "  feature/* -> dev"
-            echo "  release/* -> main"
-            echo "  hotfix/* -> main"
+            echo "  release/<semver> -> main"
+            echo "  hotfix/<semver> -> main"
             exit 1
           fi
 

--- a/.github/workflows/version-integrity-main-pr.yml
+++ b/.github/workflows/version-integrity-main-pr.yml
@@ -37,22 +37,15 @@ jobs:
           if base_ref != "main":
               raise SystemExit(f"This workflow only supports PRs to main, got base={base_ref!r}")
 
-          if head_ref.startswith("release/"):
-              release_match = re.fullmatch(r"release/(\d+\.\d+\.\d+)", head_ref)
-              if not release_match:
-                  raise SystemExit(
-                      "Release PRs to main must use a SemVer branch suffix "
-                      "(e.g. release/1.2.3)."
-                  )
-              branch_type = "release"
-              branch_version = release_match.group(1)
-          elif head_ref.startswith("hotfix/"):
-              branch_type = "hotfix"
-              branch_version = None
-          else:
+          branch_match = re.fullmatch(r"(release|hotfix)/(\d+\.\d+\.\d+)", head_ref)
+          if not branch_match:
               raise SystemExit(
-                  "PRs to main must come from release/* or hotfix/* branches."
+                  "PRs to main must come from release/* or hotfix/* with SemVer suffix "
+                  "(e.g. release/1.2.3 or hotfix/1.2.3)."
               )
+
+          branch_type = branch_match.group(1)
+          branch_version = branch_match.group(2)
 
           pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
           project_version = pyproject["project"]["version"]
@@ -84,11 +77,10 @@ jobs:
               ) from exc
 
           checks = {
+              "branch": branch_version,
               "pyproject.toml": project_version,
               "VersionHistory.md top entry": history_version,
           }
-          if branch_version:
-              checks["release branch suffix"] = branch_version
           if init_version:
               checks["src/mv_laplace/__init__.py"] = init_version
           else:
@@ -102,7 +94,6 @@ jobs:
 
           print("Version integrity check passed.")
           print(f"- Branch type: {branch_type}")
-          print(f"- Branch ref: {head_ref}")
           print(f"- Version: {unique_versions[0]}")
           print(f"- VersionHistory date: {history_date}")
           PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ These instructions apply to the entire repo tree.
   - `main`: production-ready history only.
   - `dev`: integration branch for upcoming work.
   - `feature/*`: branch from `dev`, merge back into `dev`.
-  - `release/*`: branch from `dev`, merge into `main` only.
-  - `hotfix/*`: branch from `main`, merge into `main` only.
+  - `release/<MAJOR.MINOR.PATCH>`: branch from `dev`, merge into `main` only.
+  - `hotfix/<MAJOR.MINOR.PATCH>`: branch from `main`, merge into `main` only.
 - Contribution scope:
   - Community contributors are welcome to propose changes through `feature/* -> dev` pull requests.
   - `release/*` and `hotfix/*` branches and pull requests are core-developer managed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ uv run pytest -q
 - Start feature work from `dev`:
   - `feature/<name> -> dev`
 - Releases and hotfixes are managed by core developers:
-  - `release/<semver> -> main`
-  - `hotfix/<semver> -> main`
+  - `release/<semver> -> main` (required SemVer branch suffix, e.g. `release/0.2.0`)
+  - `hotfix/<semver> -> main` (required SemVer branch suffix, e.g. `hotfix/0.2.1`)
 
 ## Versioning and Release Notes
 - Follow Semantic Versioning (`MAJOR.MINOR.PATCH`).

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See [`VersionHistory.md`](VersionHistory.md).
 ## Repository Policy
 High-level development policy summary (full details in [`AGENTS.md`](AGENTS.md)):
 - GitFlow is used: `feature/* -> dev`, `release/*|hotfix/* -> main`, with PR-based merges.
+- Release and hotfix branches must use SemVer suffixes: `release/<MAJOR.MINOR.PATCH>`, `hotfix/<MAJOR.MINOR.PATCH>`.
 - Community contributions are welcome through `feature/* -> dev` pull requests; `release/*` and `hotfix/*` flows are core-developer managed.
 - CI runs on PRs to `dev` and `main`; release dry-runs run on `release/*`/`hotfix/*` PRs to `main`; release publish runs after merge to `main`.
 - Semantic Versioning is required (`MAJOR.MINOR.PATCH`) and versioning must be intentional.

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,12 @@
 # Version History
 
+## v0.2.1 (2026/03/03)
+* Fixed release-note generation in `deploy-on-main-merge.yml` by escaping regex quantifier braces inside an f-string pattern.
+* Restored strict SemVer branch policy for `release/*` and `hotfix/*` PRs to `main` in `version-integrity-main-pr.yml`.
+* Restored hotfix patch-only release gate in `deploy-on-main-merge.yml` (`hotfix/*` merges must increment patch only).
+* Tightened GitFlow PR branch-path checks to require SemVer suffixes for `release/<semver>` and `hotfix/<semver>` when targeting `main`.
+* Updated policy/docs (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`) to reflect required SemVer-suffixed release/hotfix branch naming.
+
 ## v0.2.0 (2026/03/03)
 * Added `random_state` support to `MvLaplaceSampler.sample(...)` for reproducible sampling.
 * Replaced global-seed test patterns with RNG-isolated tests and expanded sampling/reproducibility coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mv-laplace"
-version = "0.2.0"
+version = "0.2.1"
 description = "Sampler-focused multivariate Laplace implementation for simulation workflows."
 readme = "README.md"
 license = { text = "GPL-3.0-only" }

--- a/src/mv_laplace/__init__.py
+++ b/src/mv_laplace/__init__.py
@@ -1,4 +1,4 @@
 from .MvLaplaceSampler import MvLaplaceSampler
 
 __all__ = ["MvLaplaceSampler"]
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -3,4 +3,4 @@ import mv_laplace
 
 def test_package_exports_and_version():
     assert "MvLaplaceSampler" in mv_laplace.__all__
-    assert mv_laplace.__version__ == "0.2.0"
+    assert mv_laplace.__version__ == "0.2.1"


### PR DESCRIPTION
## Summary
- restore strict SemVer enforcement for release and hotfix branch naming in workflow policy checks
- restore hotfix patch-only gate in release validation workflow
- bump package/version markers for hotfix release `0.2.1`

## What Changed
- `.github/workflows/version-integrity-main-pr.yml`
  - require `release/<semver>` and `hotfix/<semver>` for PRs to `main`
  - require branch suffix version to match package/changelog versions
- `.github/workflows/deploy-on-main-merge.yml`
  - restore hotfix policy requiring patch-only increment over previous release
- `.github/workflows/gitflow-pr-rules.yml`
  - enforce SemVer suffix for `release/*` and `hotfix/*` PR heads targeting `main`
- policy/docs alignment
  - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`
- version markers updated to `0.2.1`
  - `pyproject.toml`, `src/mv_laplace/__init__.py`, `tests/test_package_metadata.py`, `VersionHistory.md`

## Validation
- local tests: `20 passed`
- policy/workflow rules now consistently require SemVer-suffixed release/hotfix branch names

## Notes
- This PR is intentionally non-draft, as requested.
